### PR TITLE
Fix gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,6 @@ DEPENDENCIES
   bourne
   bundler
   capybara
-  cocaine (~> 0.2)
   cucumber (~> 1.2.1)
   fakeweb
   fog (>= 1.4.0, < 1.7.0)
@@ -198,3 +197,6 @@ DEPENDENCIES
   rake
   shoulda
   sqlite3
+
+BUNDLED WITH
+   1.10.3

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('nokogiri')
   s.add_development_dependency('capybara')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('cocaine', '~> 0.2')
   s.add_development_dependency('fog', '>= 1.4.0', "< 1.7.0")
   s.add_development_dependency('pry')
   s.add_development_dependency('launchy')


### PR DESCRIPTION
Double dependency on cocaine broke with the newest version of bundler
(1.10.3).

(And let's be honest, double dependency on cocaine isn't good for
anyone.)
